### PR TITLE
Run apt-get update before installing postgres

### DIFF
--- a/OC4IDS_Database_Data_Import.ipynb
+++ b/OC4IDS_Database_Data_Import.ipynb
@@ -122,6 +122,7 @@
       "source": [
         "%%shell\n",
         "\n",
+        "sudo apt-get update",
         "sudo apt-get install -y postgresql-client"
       ],
       "execution_count": null,


### PR DESCRIPTION
apt-get install fails to fetch the postgres package, so this step is necessary.