### PR TITLE
Remove trailing whitespace in %load_ext sql

### DIFF
--- a/OC4IDS_CoST_IDS_Coverage.ipynb
+++ b/OC4IDS_CoST_IDS_Coverage.ipynb
@@ -1,16 +1,4 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "colab": {
-      "name": "OC4IDS CoST IDS Coverage",
-      "provenance": []
-    },
-    "kernelspec": {
-      "name": "python3",
-      "display_name": "Python 3"
-    }
-  },
   "cells": [
     {
       "cell_type": "markdown",
@@ -56,18 +44,21 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "27yRx-oaXPtd"
+        "id": "27yRx-oaXPtd",
+        "vscode": {
+          "languageId": "python"
+        }
       },
+      "outputs": [],
       "source": [
         "import getpass\n",
         "\n",
         "print('Enter your credentials')\n",
         "user = input('Username:')\n",
         "password = getpass.getpass('Password:')"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -80,9 +71,14 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "PZShlCS_ToCe"
+        "id": "PZShlCS_ToCe",
+        "vscode": {
+          "languageId": "python"
+        }
       },
+      "outputs": [],
       "source": [
         "# https://ocdskit.readthedocs.io/\n",
         "!pip install ocdskit\n",
@@ -91,7 +87,7 @@
         "\n",
         "# https://pypi.org/project/ipython-sql/\n",
         "!pip install --upgrade ipython-sql > pip.log\n",
-        "%load_ext sql \n",
+        "%load_ext sql\n",
         "%sql $connection_string\n",
         "%config SqlMagic.autopandas = True  # Return Pandas DataFrames instead of regular result sets\n",
         "%config SqlMagic.displaycon = False  # Don't show connection string after execute\n",
@@ -115,9 +111,7 @@
         "  content = response.content.decode('utf-8').splitlines(keepends=True)\n",
         "\n",
         "  return csv.DictReader(content, quotechar='\"')"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -139,14 +133,17 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "dZv0vp_bToCr"
+        "id": "dZv0vp_bToCr",
+        "vscode": {
+          "languageId": "python"
+        }
       },
+      "outputs": [],
       "source": [
         "collection_id = 50"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -159,9 +156,14 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "VO2tADcLToCp"
+        "id": "VO2tADcLToCp",
+        "vscode": {
+          "languageId": "python"
+        }
       },
+      "outputs": [],
       "source": [
         "%%sql\n",
         "\n",
@@ -180,9 +182,7 @@
         "  data_version\n",
         " order by\n",
         "  collection.id desc;"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -204,9 +204,14 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "YQCEeYswJ2do"
+        "id": "YQCEeYswJ2do",
+        "vscode": {
+          "languageId": "python"
+        }
       },
+      "outputs": [],
       "source": [
         "import csv\n",
         "import requests\n",
@@ -284,9 +289,7 @@
         "          element['fields'][field]['coverage'] = 0\n",
         "\n",
         "      elements.append(element)\n"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -299,9 +302,14 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "Blk4IYlcPtR8"
+        "id": "Blk4IYlcPtR8",
+        "vscode": {
+          "languageId": "python"
+        }
       },
+      "outputs": [],
       "source": [
         "from google.colab import files\n",
         "\n",
@@ -319,9 +327,19 @@
         "    writer.writerow(row)\n",
         "\n",
         "files.download('coverage.csv')"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     }
-  ]
+  ],
+  "metadata": {
+    "colab": {
+      "name": "OC4IDS CoST IDS Coverage",
+      "provenance": []
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
 }

--- a/OC4IDS_Data_Feedback_Notebook.ipynb
+++ b/OC4IDS_Data_Feedback_Notebook.ipynb
@@ -1,45 +1,4 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "kernelspec": {
-      "display_name": "Python 3",
-      "language": "python",
-      "name": "python3"
-    },
-    "language_info": {
-      "codemirror_mode": {
-        "name": "ipython",
-        "version": 3
-      },
-      "file_extension": ".py",
-      "mimetype": "text/x-python",
-      "name": "python",
-      "nbconvert_exporter": "python",
-      "pygments_lexer": "ipython3",
-      "version": "3.8.2"
-    },
-    "colab": {
-      "name": "OC4IDS_Data_Feedback_Notebook.ipynb",
-      "provenance": [],
-      "collapsed_sections": [
-        "Us11kt9cMaqX",
-        "RBgIdb4Qvu0k",
-        "mnjUxidtMaqc",
-        "fGihA30uMaqi",
-        "KmU04Zk0Maqo",
-        "kkwh_Jd5Maqr",
-        "E1k8rcPjMaqv",
-        "06NAYhtAMaq8",
-        "7ip-7SoXMarA",
-        "bm9jlHH8MarE",
-        "jBy1ujx9dUiU",
-        "HNDCwR2jeqiV",
-        "3rG9rOmOEn2m"
-      ],
-      "toc_visible": true
-    }
-  },
   "cells": [
     {
       "cell_type": "markdown",
@@ -74,9 +33,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "27yRx-oaXPtd"
       },
+      "outputs": [],
       "source": [
         "# Get database credentials. OCDS Helpdesk analysts, see https://crm.open-contracting.org/issues/6335.\n",
         "import getpass\n",
@@ -84,9 +45,7 @@
         "print('Enter your credentials')\n",
         "user = input('Username:')\n",
         "password = getpass.getpass('Password:')"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -99,16 +58,18 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "VjuPJaBUMapU"
       },
+      "outputs": [],
       "source": [
         "!pip install --upgrade ipython-sql > pip.log\n",
         "\n",
         "connection_string = 'postgresql://' + user + ':' + password + '@database-1.cmc8bohiuyg3.us-east-1.rds.amazonaws.com/postgres'\n",
         "\n",
         "# https://pypi.org/project/ipython-sql/\n",
-        "%load_ext sql \n",
+        "%load_ext sql\n",
         "%sql $connection_string\n",
         "%config SqlMagic.autopandas = True  # Return Pandas DataFrames instead of regular result sets\n",
         "%config SqlMagic.displaycon = False  # Don't show connection string after execute\n",
@@ -168,9 +129,7 @@
         "# Needs updating to support other locales\n",
         "def format_thousands(axis):\n",
         "  axis.set_major_formatter(tkr.FuncFormatter(lambda x, pos: '{:,.0f}'.format(x)))"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -201,9 +160,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "vp4FUPxaYP5T"
       },
+      "outputs": [],
       "source": [
         "%%sql\n",
         "\n",
@@ -222,9 +183,7 @@
         "  data_version\n",
         " order by\n",
         "  collection.id desc;"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -237,14 +196,14 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "uVLcOKqHMaqH"
       },
+      "outputs": [],
       "source": [
         "collection_id = 30"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -266,9 +225,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "zsr_R5ljMaqM"
       },
+      "outputs": [],
       "source": [
         "%%sql\n",
         "\n",
@@ -278,9 +239,7 @@
         "    projects\n",
         "where\n",
         "    collection_id = :collection_id"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -293,9 +252,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "qN2McEj0MaqP"
       },
+      "outputs": [],
       "source": [
         "%%sql\n",
         "\n",
@@ -307,9 +268,7 @@
         "    jsonb_array_elements(data -> 'contractingProcesses')\n",
         "where\n",
         "    collection_id = :collection_id;"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -322,9 +281,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "8l7Bs8qpMaqe"
       },
+      "outputs": [],
       "source": [
         "%%sql\n",
         "\n",
@@ -335,9 +296,7 @@
         "  projects\n",
         "where\n",
         "  collection_id = :collection_id"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -359,9 +318,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "AF3DK0svoWKw"
       },
+      "outputs": [],
       "source": [
         "%%sql\n",
         "\n",
@@ -381,9 +342,7 @@
         "order by\n",
         "  error,\n",
         "  count desc;"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -396,9 +355,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "-_p6_WA8MaqT"
       },
+      "outputs": [],
       "source": [
         "%%sql\n",
         "\n",
@@ -426,9 +387,7 @@
         "    path\n",
         "order by\n",
         "    count desc"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -459,9 +418,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "MdVCNKk0MaqY"
       },
+      "outputs": [],
       "source": [
         "%%sql\n",
         "\n",
@@ -472,9 +433,7 @@
         "where\n",
         "  collection_id = :collection_id\n",
         "    "
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -505,9 +464,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "Qb3si_3g7lnd"
       },
+      "outputs": [],
       "source": [
         "%%sql\n",
         "\n",
@@ -524,9 +485,7 @@
         "  count(*) > 1\n",
         "order by\n",
         "  count(*) desc;"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -548,9 +507,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "3S2AF1ZZMaqi"
       },
+      "outputs": [],
       "source": [
         "%%sql\n",
         "\n",
@@ -566,9 +527,7 @@
         "where\n",
         "  collection_id = :collection_id\n",
         "    "
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -593,9 +552,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "RBjaXvoDMaqm"
       },
+      "outputs": [],
       "source": [
         "%%sql\n",
         "\n",
@@ -691,9 +652,7 @@
         "  path\n",
         "ORDER BY\n",
         "  count(*) DESC;"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -724,9 +683,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "_F2xnBHpcR80"
       },
+      "outputs": [],
       "source": [
         "%%sql\n",
         "\n",
@@ -741,9 +702,7 @@
         "  collection_id = :collection_id\n",
         "group by\n",
         "  scheme;"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -774,9 +733,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "6lN3g4mrc8zU"
       },
+      "outputs": [],
       "source": [
         "%%sql\n",
         "\n",
@@ -793,9 +754,7 @@
         "  collection_id = :collection_id\n",
         "group by\n",
         "  scheme;"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -826,9 +785,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "rS0XluxsMaqp"
       },
+      "outputs": [],
       "source": [
         "%%sql project_status <<\n",
         "\n",
@@ -862,15 +823,15 @@
         "  projects_by_status using (status) \n",
         "order by\n",
         "  ordering asc;"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "ychmRg9HhOK6"
       },
+      "outputs": [],
       "source": [
         "project_status_chart = sns.catplot(data = project_status, kind=\"bar\", x=\"status\", y=\"project_count\")\n",
         "\n",
@@ -878,9 +839,7 @@
         "\n",
         "for ax in project_status_chart.axes.flat:\n",
         "  format_thousands(ax.yaxis)"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -902,9 +861,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "Mym_RorwMaqs"
       },
+      "outputs": [],
       "source": [
         "%%sql project_sector <<\n",
         "\n",
@@ -919,23 +880,21 @@
         "  sector\n",
         "order by\n",
         "  project_count desc;"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "SU6G4w8hhgDP"
       },
+      "outputs": [],
       "source": [
         "project_sector_chart = sns.catplot(data = project_sector, kind=\"bar\", x=\"project_count\", y=\"sector\")\n",
         "\n",
         "for ax in project_sector_chart.axes.flat:\n",
         "  format_thousands(ax.xaxis)"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -957,9 +916,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "H3Vek_YtMaqv"
       },
+      "outputs": [],
       "source": [
         "%%sql project_type <<\n",
         "\n",
@@ -974,23 +935,21 @@
         "  type\n",
         "order by\n",
         "  count(*) desc;"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "-M1qRRuthnL1"
       },
+      "outputs": [],
       "source": [
         "project_type_chart = sns.catplot(data = project_type, kind=\"bar\", x=\"project_count\", y=\"type\")\n",
         "\n",
         "for ax in project_type_chart.axes.flat:\n",
         "  format_thousands(ax.xaxis)"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -1012,9 +971,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "DgqSFkrGMaq9"
       },
+      "outputs": [],
       "source": [
         "%%sql public_authority <<\n",
         "\n",
@@ -1031,23 +992,21 @@
         "  project_count desc\n",
         "limit\n",
         "  10;"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "x3PRRZ49kIuM"
       },
+      "outputs": [],
       "source": [
         "public_authority_chart = sns.catplot(data = public_authority, kind=\"bar\", x=\"project_count\", y=\"public_authority\")\n",
         "\n",
         "for ax in public_authority_chart.axes.flat:\n",
         "  format_thousands(ax.xaxis)"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -1069,9 +1028,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "eb_2qPtbh-74"
       },
+      "outputs": [],
       "source": [
         "%%sql project_budget <<\n",
         "\n",
@@ -1084,15 +1045,15 @@
         "  collection_id = :collection_id\n",
         "and\n",
         "  coalesce((data -> 'budget' -> 'amount' ->> 'amount')::numeric) >0;\n"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "9eCKL6Qh7iWP"
       },
+      "outputs": [],
       "source": [
         "project_budget['budget'] = pd.to_numeric(project_budget['budget'])\n",
         "\n",
@@ -1103,9 +1064,7 @@
         "for ax in grid.axes.flat:\n",
         "    ax.set_xticklabels(ax.get_xticklabels(), rotation=45)\n",
         "    format_thousands(ax.xaxis)"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -1127,9 +1086,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "ks6KnDRQMarE"
       },
+      "outputs": [],
       "source": [
         "%%sql\n",
         "\n",
@@ -1144,9 +1105,7 @@
         "  collection_id = :collection_id\n",
         "group by\n",
         "  roles;"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -1168,9 +1127,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "9mj13UuuMarK"
       },
+      "outputs": [],
       "source": [
         "%%sql\n",
         "\n",
@@ -1190,9 +1151,7 @@
         "  random()\n",
         "limit\n",
         "  3;"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -1214,9 +1173,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "j0hgDvDxdm4s"
       },
+      "outputs": [],
       "source": [
         "%%sql contracting_process_counts <<\n",
         "\n",
@@ -1231,23 +1192,21 @@
         "  contracting_process_count\n",
         "order by\n",
         "  contracting_process_count asc;"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "3lDBaQXFviMr"
       },
+      "outputs": [],
       "source": [
         "contracting_process_count_chart = sns.catplot(data=contracting_process_counts, kind='bar', x='contracting_process_count', y='project_count')\n",
         "\n",
         "for ax in contracting_process_count_chart.axes.flat:\n",
         "  format_thousands(ax.yaxis)"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -1269,14 +1228,14 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "BgjMOu0am8bD"
       },
+      "outputs": [],
       "source": [
         "currency = 'UAH'"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -1289,9 +1248,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "_R_Sb60rEx_I"
       },
+      "outputs": [],
       "source": [
         "%%sql contract_value <<\n",
         "\n",
@@ -1308,15 +1269,15 @@
         "--  contractingProcesses -> 'summary' -> 'contractValue' ->> 'currency' = :currency\n",
         "and\n",
         "  contractingProcesses -> 'summary' -> 'contractValue' ->> 'amount' is not null;"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "_RCi3LgZwv_U"
       },
+      "outputs": [],
       "source": [
         "contract_value['value'] = pd.to_numeric(contract_value['value'])\n",
         "\n",
@@ -1327,9 +1288,7 @@
         "    ax.set_xticklabels(ax.get_xticklabels(), rotation=45)\n",
         "    format_thousands(ax.xaxis)\n",
         "  "
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -1353,9 +1312,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "6Yojv315uhy3"
       },
+      "outputs": [],
       "source": [
         "%%sql coverage <<\n",
         "\n",
@@ -1405,34 +1366,37 @@
         "\tarray_to_string(field_counts.path_array[1:array_length(field_counts.path_array,\n",
         "\t1)-1],\n",
         "\t'/') = parent_field_counts.PATH;\n"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "coverage"
-      ],
+      "execution_count": null,
       "metadata": {
         "id": "S91s0IP_swmY"
       },
-      "execution_count": null,
-      "outputs": []
+      "outputs": [],
+      "source": [
+        "coverage"
+      ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "UO3i5BVOC1YG"
+      },
       "source": [
         "#### Important fields\n",
         "\n",
         "Check the coverage of fields needed to calculate OC4IDS indicators"
-      ],
-      "metadata": {
-        "id": "UO3i5BVOC1YG"
-      }
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "_k6K9uUOqHul"
+      },
+      "outputs": [],
       "source": [
         "import csv\n",
         "import requests\n",
@@ -1459,12 +1423,48 @@
         "# Sort and display the DataFrame\n",
         "coverage.reset_index(inplace=True)\n",
         "coverage.sort_values(by=['indicators'], ascending=False)"
-      ],
-      "metadata": {
-        "id": "_k6K9uUOqHul"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     }
-  ]
+  ],
+  "metadata": {
+    "colab": {
+      "collapsed_sections": [
+        "Us11kt9cMaqX",
+        "RBgIdb4Qvu0k",
+        "mnjUxidtMaqc",
+        "fGihA30uMaqi",
+        "KmU04Zk0Maqo",
+        "kkwh_Jd5Maqr",
+        "E1k8rcPjMaqv",
+        "06NAYhtAMaq8",
+        "7ip-7SoXMarA",
+        "bm9jlHH8MarE",
+        "jBy1ujx9dUiU",
+        "HNDCwR2jeqiV",
+        "3rG9rOmOEn2m"
+      ],
+      "name": "OC4IDS_Data_Feedback_Notebook.ipynb",
+      "provenance": [],
+      "toc_visible": true
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.8.2"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
 }

--- a/OC4IDS_Indicator_Coverage.ipynb
+++ b/OC4IDS_Indicator_Coverage.ipynb
@@ -1,23 +1,10 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "colab": {
-      "name": "OC4IDS Indicator Coverage",
-      "provenance": [],
-      "include_colab_link": true
-    },
-    "kernelspec": {
-      "name": "python3",
-      "display_name": "Python 3"
-    }
-  },
   "cells": [
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "view-in-github",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "view-in-github"
       },
       "source": [
         "<a href=\"https://colab.research.google.com/github/open-contracting/notebooks-oc4ids/blob/indicator_coverage/OC4IDS_Indicator_Coverage.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
@@ -65,18 +52,21 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "27yRx-oaXPtd"
+        "id": "27yRx-oaXPtd",
+        "vscode": {
+          "languageId": "python"
+        }
       },
+      "outputs": [],
       "source": [
         "import getpass\n",
         "\n",
         "print('Enter your credentials')\n",
         "user = input('Username:')\n",
         "password = getpass.getpass('Password:')"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -89,9 +79,14 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "PZShlCS_ToCe"
+        "id": "PZShlCS_ToCe",
+        "vscode": {
+          "languageId": "python"
+        }
       },
+      "outputs": [],
       "source": [
         "# https://ocdskit.readthedocs.io/\n",
         "!pip install ocdskit\n",
@@ -100,7 +95,7 @@
         "\n",
         "# https://pypi.org/project/ipython-sql/\n",
         "!pip install --upgrade ipython-sql > pip.log\n",
-        "%load_ext sql \n",
+        "%load_ext sql\n",
         "%sql $connection_string\n",
         "%config SqlMagic.autopandas = True  # Return Pandas DataFrames instead of regular result sets\n",
         "%config SqlMagic.displaycon = False  # Don't show connection string after execute\n",
@@ -124,9 +119,7 @@
         "  content = response.content.decode('utf-8').splitlines(keepends=True)\n",
         "\n",
         "  return csv.DictReader(content, quotechar='\"')"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -148,14 +141,17 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "dZv0vp_bToCr"
+        "id": "dZv0vp_bToCr",
+        "vscode": {
+          "languageId": "python"
+        }
       },
+      "outputs": [],
       "source": [
         "collection_id = 41"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -168,9 +164,14 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "VO2tADcLToCp"
+        "id": "VO2tADcLToCp",
+        "vscode": {
+          "languageId": "python"
+        }
       },
+      "outputs": [],
       "source": [
         "%%sql\n",
         "\n",
@@ -189,9 +190,7 @@
         "  data_version\n",
         " order by\n",
         "  collection.id desc;"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -213,17 +212,20 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "Gyi-3pMxwKPI"
+        "id": "Gyi-3pMxwKPI",
+        "vscode": {
+          "languageId": "python"
+        }
       },
+      "outputs": [],
       "source": [
         "%%shell\n",
         "\n",
         "curl 'https://standard.open-contracting.org/infrastructure/latest/en/project-schema.json' > project-schema.json\n",
         "ocdskit mapping-sheet project-schema.json > project-schema.csv"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -236,9 +238,14 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "F5gqx0hoALW8"
+        "id": "F5gqx0hoALW8",
+        "vscode": {
+          "languageId": "python"
+        }
       },
+      "outputs": [],
       "source": [
         "with open('project-schema.csv', 'r') as f:\n",
         "\n",
@@ -336,9 +343,7 @@
         "    row = dict(indicator)\n",
         "    row.pop('methods')\n",
         "    writer.writerow(row)"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -351,14 +356,17 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "zoDL0w-WxhfA"
+        "id": "zoDL0w-WxhfA",
+        "vscode": {
+          "languageId": "python"
+        }
       },
+      "outputs": [],
       "source": [
         "files.download('coverage.csv')"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -371,15 +379,18 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "M8d2-G-OalA6"
+        "id": "M8d2-G-OalA6",
+        "vscode": {
+          "languageId": "python"
+        }
       },
+      "outputs": [],
       "source": [
         "coverage_summary = pd.DataFrame.from_dict(indicators, orient='index')\n",
         "coverage_summary = coverage_summary[coverage_summary['deprecated'] == 'FALSE']"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -392,9 +403,14 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "6XAI5Ttch0gD"
+        "id": "6XAI5Ttch0gD",
+        "vscode": {
+          "languageId": "python"
+        }
       },
+      "outputs": [],
       "source": [
         "coverage_summary['calculable'] = coverage_summary['coverage'] > 0\n",
         "calculable = coverage_summary[['id', 'calculable', 'use_case']].groupby(['use_case','calculable']).count()\n",
@@ -403,9 +419,7 @@
         "plt.figure(figsize = (15,8))\n",
         "ax = sns.histplot(calculable, x='use_case', hue='calculable', weights='id', multiple='stack')\n",
         "plt.xticks(rotation=45)"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -418,9 +432,14 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "M8UYJCyCjcfz"
+        "id": "M8UYJCyCjcfz",
+        "vscode": {
+          "languageId": "python"
+        }
       },
+      "outputs": [],
       "source": [
         "def coverage_bin(coverage):\n",
         "  if coverage < 0.33:\n",
@@ -433,9 +452,20 @@
         "coverage_summary['coverage_bin'] = coverage_summary.apply(lambda x: coverage_bin(x['coverage']), axis=1)\n",
         "\n",
         "ax = sns.countplot(x='coverage_bin', order=['<33%', '33-66%', '>66%'], data=coverage_summary)"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     }
-  ]
+  ],
+  "metadata": {
+    "colab": {
+      "include_colab_link": true,
+      "name": "OC4IDS Indicator Coverage",
+      "provenance": []
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
 }


### PR DESCRIPTION
Something changed in the way that Colaboratory parses the `%load_ext` magic, which causes it to fail when there is a trailing space after the extension name.

This PR removes the trailing space after `%load_ext sql`