### PR TITLE
Use Google Sheets CSV for project prefix checks

### DIFF
--- a/OC4IDS_Quality_Criteria_Checks_and_Metrics.ipynb
+++ b/OC4IDS_Quality_Criteria_Checks_and_Metrics.ipynb
@@ -180,8 +180,32 @@
         "  %sql {query}"
       ],
       "metadata": {
-        "id": "XjtR-NQpFGKA",
-        "cellView": "form"
+        "id": "XjtR-NQpFGKA"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# @title ### Fetch prefixes\n",
+        "\n",
+        "import pandas as pd\n",
+        "import io\n",
+        "\n",
+        "prefix_url = \"https://docs.google.com/spreadsheets/d/e/2PACX-1vTWtoIa_26k35bmZVGiAziNMvdUgDS93ZM2j99XidgHaoQxm9C2dbnblckB0ZF7NUKJ6RrpDS7OQvxl/pub?gid=506986894&single=true&output=csv\"\n",
+        "\n",
+        "try:\n",
+        "    response = requests.get(prefix_url)\n",
+        "    response.raise_for_status()\n",
+        "    prefix_csv = io.StringIO(response.text)\n",
+        "    df = pd.read_csv(prefix_csv)\n",
+        "    registered_prefixes = tuple(df['Prefix'])\n",
+        "except Exception as e:\n",
+        "    print(e)"
+      ],
+      "metadata": {
+        "id": "TifkJDV-2LIy"
       },
       "execution_count": null,
       "outputs": []
@@ -345,11 +369,7 @@
         "        AND\n",
         "        LEFT (project_id,\n",
         "            13)\n",
-        "        NOT IN (\n",
-        "            SELECT\n",
-        "                prefix\n",
-        "            FROM\n",
-        "                registered_prefixes)\n",
+        "        NOT IN :registered_prefixes\n",
         "        GROUP BY\n",
         "            collection_id)\n",
         "    INSERT INTO check_results (run_id, check_id, collection_id, result, output)\n",


### PR DESCRIPTION
- **Extracts prefixes from CSV:** Fetches the prefix list from a public Google Sheets URL using pandas and converts it to a tuple.
- **Updates SQL query:** Modifies the `criteria_registered` check to use the fetched prefixes