### PR TITLE
Update IDS coverage notebook

### DIFF
--- a/OC4IDS_CoST_IDS_Coverage.ipynb
+++ b/OC4IDS_CoST_IDS_Coverage.ipynb
@@ -253,7 +253,7 @@
         "\n",
         "\"\"\"\n",
         "\n",
-        "base_url = 'https://standard.open-contracting.org/staging/infrastructure/0.9-dev/en/_static/project-level/'\n",
+        "base_url = 'https://standard.open-contracting.org/infrastructure/latest/en/_static/project-level/'\n",
         "\n",
         "csv_files = [\n",
         "  'process-level-implementation.csv',\n",


### PR DESCRIPTION
- Closes #41 using logic from the publisher status report notebooks. 
- Hardcodes `username` to `readonly`.
- Adds `%config SqlMagic.style = '_DEPRECATED_DEFAULT'` to fix `KeyError: 'default'` caused by an incompatibility with newer versions of the prettytable library.